### PR TITLE
add orbit camera

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ approx = "0.4"
 ron = "0.6"
 serde = "1.0"
 thread_local = "1.0"
+bevy-orbit-controls = { git = "https://github.com/rezural/bevy-orbit-controls.git", rev = "aa7abae" }
 
 [dependencies.bevy]
 version = "0.5"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Unreal Engine style mouse camera.
 - Right drag: Change viewing angle
 - Left and Right drag: Translate up/down/left/right
 
+Orbital Camera
+- CTRL + mouse: Orbit camera
+- Middle click + mouse: Pan camera
+- Mouse wheel: Zoom
+
 ### Editing Tools
 
 - `T`: Enter terraforming mode

--- a/config.ron
+++ b/config.ron
@@ -1,3 +1,4 @@
 (
     wireframes: false,
+    camera: Unreal,
 )

--- a/src/bin/editor.rs
+++ b/src/bin/editor.rs
@@ -30,6 +30,7 @@ fn main() -> Result<(), ron::Error> {
             ..Default::default()
         })
         .insert_resource(WireframeConfig { global: true })
+        .insert_resource(config)
         .add_plugins(BevyPlugins::new(config))
         // Editor stuff.
         .add_plugin(EditorPlugin)

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -2,6 +2,10 @@ mod controller;
 mod cursor_ray;
 mod orbit_transform;
 
+mod orbit_controller;
+
+use crate::{config::CameraType, Config};
+
 pub use controller::{mouse_camera_control_system, CameraControlConfig, MouseCameraController};
 pub use cursor_ray::{CursorRay, CursorRayCalculator, CursorRayCameraTag};
 
@@ -10,6 +14,19 @@ use cursor_ray::CursorRayPlugin;
 use bevy::{
     app::prelude::*, ecs::prelude::*, math::prelude::*, render::prelude::*, transform::prelude::*,
 };
+
+pub fn create_camera_entity(
+    commands: &mut Commands,
+    control_config: CameraControlConfig,
+    config: Config,
+    eye: Vec3,
+    target: Vec3,
+) -> Entity {
+    match config.camera {
+        CameraType::Unreal => create_unreal_camera_entity(commands, control_config, eye, target),
+        CameraType::Orbit => create_orbit_camera_entity(commands, eye, target),
+    }
+}
 
 pub struct CameraPlugin;
 
@@ -20,7 +37,7 @@ impl Plugin for CameraPlugin {
     }
 }
 
-pub fn create_camera_entity(
+pub fn create_unreal_camera_entity(
     commands: &mut Commands,
     control_config: CameraControlConfig,
     eye: Vec3,
@@ -33,5 +50,38 @@ pub fn create_camera_entity(
         })
         .insert(CursorRayCameraTag)
         .insert(MouseCameraController::new(control_config, eye, target))
+        .id()
+}
+
+pub struct OrbitCameraPlugin;
+
+impl Plugin for OrbitCameraPlugin {
+    fn build(&self, app: &mut AppBuilder) {
+        app.add_system(orbit_controller::orbit_camera_default_input_map.system())
+            .add_system(bevy_orbit_controls::OrbitCameraPlugin::mouse_motion_system.system())
+            .add_system(bevy_orbit_controls::OrbitCameraPlugin::emit_zoom_events.system())
+            .add_system(bevy_orbit_controls::OrbitCameraPlugin::zoom_system.system())
+            .add_system(bevy_orbit_controls::OrbitCameraPlugin::update_transform_system.system())
+            .add_event::<bevy_orbit_controls::CameraEvents>()
+            .add_plugin(CursorRayPlugin);
+    }
+}
+
+pub fn create_orbit_camera_entity(commands: &mut Commands, eye: Vec3, target: Vec3) -> Entity {
+    let distance = (target - eye).length();
+    let controller = bevy_orbit_controls::OrbitCamera {
+        distance,
+        center: target,
+        pan_sensitivity: 10.0,
+        ..Default::default()
+    };
+
+    commands
+        .spawn_bundle(PerspectiveCameraBundle {
+            transform: Transform::from_translation(eye).looking_at(target, Vec3::Y),
+            ..Default::default()
+        })
+        .insert(CursorRayCameraTag)
+        .insert(controller)
         .id()
 }

--- a/src/camera/orbit_controller.rs
+++ b/src/camera/orbit_controller.rs
@@ -1,0 +1,30 @@
+use bevy::{
+    app::prelude::*,
+    ecs::prelude::*,
+    input::{mouse::MouseMotion, prelude::*},
+    math::prelude::*,
+};
+
+use bevy_orbit_controls::*;
+
+pub fn orbit_camera_default_input_map(
+    mut events: EventWriter<CameraEvents>,
+    mut mouse_motion_events: EventReader<MouseMotion>,
+    mouse_button_input: Res<Input<MouseButton>>,
+    keyboard: Res<Input<KeyCode>>,
+    mut query: Query<&OrbitCamera>,
+) {
+    let mut delta = Vec2::ZERO;
+    for event in mouse_motion_events.iter() {
+        delta += event.delta;
+    }
+    for camera in query.iter_mut() {
+        if keyboard.pressed(KeyCode::LControl) {
+            events.send(CameraEvents::Orbit(delta));
+        }
+
+        if mouse_button_input.pressed(camera.pan_button) {
+            events.send(CameraEvents::Pan(delta));
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,9 @@
 use serde::Deserialize;
 
-#[derive(Clone, Copy, Deserialize)]
+#[derive(Clone, Copy, Deserialize, Default)]
 pub struct Config {
     pub wireframes: bool,
+    pub camera: CameraType,
 }
 
 impl Config {
@@ -10,5 +11,17 @@ impl Config {
         let reader = std::fs::File::open(path)?;
 
         ron::de::from_reader(reader)
+    }
+}
+
+#[derive(Clone, Copy, Deserialize)]
+pub enum CameraType {
+    Unreal,
+    Orbit,
+}
+
+impl Default for CameraType {
+    fn default() -> Self {
+        CameraType::Unreal
     }
 }


### PR DESCRIPTION
This loads camera type from config.ron, which defaults to Unreal,

and loads either the CameraPlugin, or the OrbitCameraPlugin.

Couple of possible issues:

I havent renamed CameraPlugin to UnrealCameraPlugin, which I can do.

See the FIXME: It's a bit ugly, but im not sure how else to have the OrbitController create the inner controller